### PR TITLE
Make SGLIB_DL_LIST_ADD consistent with SGLIB_LIST_ADD

### DIFF
--- a/sglib.h
+++ b/sglib.h
@@ -557,6 +557,7 @@
 
 #define SGLIB_DL_LIST_ADD(type, list, elem, previous, next) {\
   SGLIB_DL_LIST_ADD_BEFORE(type, list, elem, previous, next)\
+  (list) = (elem);\
 }
 
 #define SGLIB___DL_LIST_GENERIC_ADD_IF_NOT_MEMBER(type, list, elem, comparator, previous, next, member, the_add_operation) {\


### PR DESCRIPTION
SGLIB_DL_LIST_ADD should also update the list pointer so it behaves just
like SGLIB_LIST_ADD. Only SGLIB_DL_LIST_ADD_AFTER/BEFORE should not
update the list pointer.

After:

    sglib_test_t_add(&list, &a);
    sglib_test_t_add(&list, &b);
    sglib_test_t_add(&list, &c);
    sglib_test_t_add(&list, &d);

The list should be d <-> c <-> b <-> a and not
a <-> d <-> c <-> b.

@stefanct This is the first bug in sglib I found, I sent it to Marian Vittek too.